### PR TITLE
PWM_ver2.1 

### DIFF
--- a/PWM_2.c
+++ b/PWM_2.c
@@ -16,12 +16,14 @@ void init(double freq, double duty)
 	PWM[2] = 1;
 }
 
-void generatingPWM(double Ts, double freq, double duty, double *Tri, double duty_ref[], double PWM[])
+void generatingPWM(double Ts, double freq, double duty, double deadtime, double *Tri, double duty_ref[], double PWM[])
 {
 
 	T = 1/freq;
 	duty_ref[0] = duty/100;
-	duty_ref[1] = (-duty/100) ;
+	duty_ref[1] = (-duty/100);
+
+	double delta_h = 1.1 * deadtime / T; //Phase change of triangular wave according to dead time setting
 
 	//If the triangluar wave needs to be updated (at the start of a new cycle)
 	if (t >= T)
@@ -31,37 +33,37 @@ void generatingPWM(double Ts, double freq, double duty, double *Tri, double duty
 	//Generate the triangular wave over the entire period
 	if (t < T/2)
 	{
-		*Tri = 1.1 * (2/T)*t - 0.55; //0에서 0.55까지
+		*Tri = 1.1 * (2/T)*t - 0.55; 
 	} else 
 	{
-		*Tri = 1.1 * (2/T)*(T-t) - 0.55; //
+		*Tri = 1.1 * (2/T)*(T-t) - 0.55; 
 	}
-	//Determine the first PWM signals based on the triangular wave (+0.01 for the deadtime) and a sine wave
-	if (*Tri + 0.01 < duty_ref[0])
+	//Determine the first PWM signals based on the triangular wave (incremented for the deadtime) and a sine wave
+	if (*Tri + delta_h < duty_ref[0])
 	{
 		PWM[0] = 1;
 	} else
 	{
 		PWM[0] = 0;
 	}
-	//Determine the first PWM signals based on the triangular wave (-0.01 for the deadtime) and inverted sine wave
-	if (*Tri - 0.01 < duty_ref[0])
+	//Determine the first PWM signals based on the triangular wave (decremented for the deadtime) and inverted sine wave
+	if (*Tri - delta_h < duty_ref[0])
 	{
 		PWM[2] = 0;
 	} else
 	{
 		PWM[2] = 1;
 	}
-	//Determine the second PWM signals based on the triangular wave (+0.01 for the deadtime) and a sine wave
-	if (*Tri + 0.01 < duty_ref[1])
+	//Determine the second PWM signals based on the triangular wave (incremented for the deadtime) and a sine wave
+	if (*Tri + delta_h < duty_ref[1])
 	{
 		PWM[1] = 1;
 	} else
 	{
 		PWM[1] = 0;
 	}
-	//Determine the second PWM signals based on the triangular wave (-0.01 for the deadtime) and inverted sine wave
-	if (*Tri - 0.01 < duty_ref[1])
+	//Determine the second PWM signals based on the triangular wave (decremented for the deadtime) and inverted sine wave
+	if (*Tri - delta_h < duty_ref[1])
 	{
 		PWM[3] = 0;
 	} else

--- a/PWM_ver2.txt
+++ b/PWM_ver2.txt
@@ -7,9 +7,10 @@ PWM4: PWM2의 compliment PWM 신호
 
 simulink 모델은 해당 PWM 신호들을 활용한 unipolar/bipolar 인버터를 포함한다.
 
-인버터의 쇼트를 방지하기 위한 데드타임이 구현되어있다. (세부사항 미포함)
+인버터의 쇼트를 방지하기 위한 데드타임이 구현되어있다. 
+데드타임 시간을 설정하면 기본/반전 PWM 각각에서 그 절반씩 데드타임을 위한 위상 변화가 생긴다. 
 ----------------------------------------------------------------------------------------------------------------
 PMW_2.c: 소스코드
 PMW_2.h: 헤더파일
 PWM_2.slx: MATLAB simulink model 파일
-running_PMW_ver2: MATLAB simulink model을 실행하고 PWM 신호를 Plot하는 MATLAB 코드
+running_PMW_ver2: MATLAB simulink model을 실행하는 MATLAB 코드


### PR DESCRIPTION
데드타임 시간 단위로 구현 가능 버전

데드타임을 설정하면 기본/반전 PWM 모두에서 각각 데드타임의 절반씩 위상 변화가 일어난다. 